### PR TITLE
Fix bad JVM argument.

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,7 +14,7 @@ variable "sonarqube_aws_env_img" {
 
 variable "sonarqube_search_jvm_opts" {
   description = "JVM options to pass to SonarQube on application start-up."
-  default     = "-Dnode.store.allow_mmap=false"
+  default     = "-Dnode.store.allow_mmapfs=false"
 }
 
 variable "health_check_grace_period_seconds" {


### PR DESCRIPTION
`-Dnode.store.allow_nmap` er ikke støttet i versjonen av ElasticSearch brukt av Sonarqube. Bruker `allow_nmapfs` i stedet.

See sonarqube ticket: https://sonarsource.atlassian.net/browse/SONAR-12264.